### PR TITLE
docs(aria): translate select material example to Italian

### DIFF
--- a/adev/src/content/examples/aria/select/src/basic/material/app/app.ts
+++ b/adev/src/content/examples/aria/select/src/basic/material/app/app.ts
@@ -31,33 +31,33 @@ import {OverlayModule} from '@angular/cdk/overlay';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class App {
-  /** The combobox listbox popup. */
+  /** Il popup listbox del combobox. */
   listbox = viewChild<Listbox<string>>(Listbox);
 
-  /** The options available in the listbox. */
+  /** Le opzioni disponibili nella listbox. */
   options = viewChildren<Option<string>>(Option);
 
-  /** A reference to the ng aria combobox. */
+  /** Un riferimento al combobox ng aria. */
   combobox = viewChild<Combobox<string>>(Combobox);
 
-  /** The string that is displayed in the combobox. */
+  /** La stringa visualizzata nel combobox. */
   displayValue = computed(() => {
     const values = this.listbox()?.values() || [];
-    return values.length ? values[0] : 'Select a label';
+    return values.length ? values[0] : 'Seleziona un\'etichetta';
   });
 
-  /** The labels that are available for selection. */
-  labels = ['Important', 'Starred', 'Work', 'Personal', 'To Do', 'Later', 'Read', 'Travel'];
+  /** Le etichette disponibili per la selezione. */
+  labels = ['Importante', 'Preferito', 'Lavoro', 'Personale', 'Da fare', 'Più tardi', 'Da leggere', 'Viaggio'];
 
   constructor() {
-    // Scrolls to the active item when the active option changes.
-    // The slight delay here is to ensure animations are done before scrolling.
+    // Scorre fino all'elemento attivo quando l'opzione attiva cambia.
+    // Il leggero ritardo serve a garantire che le animazioni siano terminate prima dello scorrimento.
     afterRenderEffect(() => {
       const option = this.options().find((opt) => opt.active());
       setTimeout(() => option?.element.scrollIntoView({block: 'nearest'}), 50);
     });
 
-    // Resets the listbox scroll position when the combobox is closed.
+    // Ripristina la posizione di scorrimento della listbox quando il combobox viene chiuso.
     afterRenderEffect(() => {
       if (!this.combobox()?.expanded()) {
         setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The file `adev/src/content/examples/aria/select/src/basic/material/app/app.ts` has English comments and user-facing strings.

Issue Number: #500

## What is the new behavior?

Translated all comments and user-facing strings to Italian:
- JSDoc comments describing component properties
- Inline comments explaining constructor logic
- Placeholder text ('Select a label' → 'Seleziona un'etichetta')
- Example label values (Important → Importante, Starred → Preferito, etc.)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Translation only — no code logic changes.